### PR TITLE
Run apt update before installing

### DIFF
--- a/docker/scripts/docker.find
+++ b/docker/scripts/docker.find
@@ -1,5 +1,6 @@
 FROM debug/find
 ENV SUBJECT findutils
+RUN sudo apt-get update
 RUN sudo apt-get install -y gdb valgrind
 ADD scripts/prepareVM.sh .
 ADD scripts/test.find.66c536bb.patch .


### PR DESCRIPTION
Initially, the valgrind package can't be found, likely due to changes since this was built.  Running an update first allows installation.